### PR TITLE
reorganise repo to allow it be imported

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
+[![](https://godoc.org/github.com/ErikDubbelboer/ringqueue?status.svg)](http://godoc.org/github.com/ErikDubbelboer/ringqueue)
+
 See: http://blog.dubbelboer.com/2015/04/25/go-faster-queue.html

--- a/memory_test.go
+++ b/memory_test.go
@@ -1,4 +1,4 @@
-package main
+package rinqueue
 
 import (
 	"math"
@@ -15,22 +15,22 @@ func benchmarkMemory(b *testing.B, q intqueue) {
 	b.N = 30000000
 
 	for i := 0; i < b.N; i++ {
-		q.add(i)
+		q.Add(i)
 	}
 
 	for i := 0; i < b.N; i++ {
-		q.remove()
+		q.Remove()
 	}
 
 	b.Logf(memory())
 }
 
 func BenchmarkSliceMemory(b *testing.B) {
-	benchmarkMemory(b, newslicequeue())
+	benchmarkMemory(b, NewSlicequeue())
 }
 
 func BenchmarkRingMemory(b *testing.B) {
-	benchmarkMemory(b, newringqueue())
+	benchmarkMemory(b, NewRingqueue())
 }
 
 func memory() string {

--- a/queues_test.go
+++ b/queues_test.go
@@ -1,30 +1,30 @@
-package main
+package rinqueue
 
 import (
 	"testing"
 )
 
 type intqueue interface {
-	add(int)
-	remove() (int, bool)
-	len() int
-	cap() int
+	Add(interface{})
+	Remove() (interface{}, bool)
+	Len() int
+	Cap() int
 }
 
 func testqueue(t *testing.T, q intqueue) {
 	for j := 0; j < 100; j++ {
-		if q.len() != 0 {
+		if q.Len() != 0 {
 			t.Fatal("expected no elements")
-		} else if _, ok := q.remove(); ok {
+		} else if _, ok := q.Remove(); ok {
 			t.Fatal("expected no elements")
 		}
 
 		for i := 0; i < j; i++ {
-			q.add(i)
+			q.Add(i)
 		}
 
 		for i := 0; i < j; i++ {
-			if x, ok := q.remove(); !ok {
+			if x, ok := q.Remove(); !ok {
 				t.Fatal("expected an element")
 			} else if x != i {
 				t.Fatalf("expected %d got %d", i, x)
@@ -36,12 +36,12 @@ func testqueue(t *testing.T, q intqueue) {
 	r := 0
 	for j := 0; j < 100; j++ {
 		for i := 0; i < 4; i++ {
-			q.add(a)
+			q.Add(a)
 			a++
 		}
 
 		for i := 0; i < 2; i++ {
-			if x, ok := q.remove(); !ok {
+			if x, ok := q.Remove(); !ok {
 				t.Fatal("expected an element")
 			} else if x != r {
 				t.Fatalf("expected %d got %d", r, x)
@@ -50,51 +50,51 @@ func testqueue(t *testing.T, q intqueue) {
 		}
 	}
 
-	if q.len() != 200 {
-		t.Fatalf("expected 200 elements have %d", q.len())
+	if q.Len() != 200 {
+		t.Fatalf("expected 200 elements have %d", q.Len())
 	}
 }
 
 func TestSlicequeue(t *testing.T) {
-	testqueue(t, newslicequeue())
+	testqueue(t, NewSlicequeue())
 }
 
 func TestRingqueue(t *testing.T) {
-	testqueue(t, newringqueue())
+	testqueue(t, NewRingqueue())
 }
 
 func benchmarkAdd(b *testing.B, q intqueue) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		q.add(i)
+		q.Add(i)
 	}
 }
 
 func BenchmarkSliceAdd(b *testing.B) {
-	benchmarkAdd(b, newslicequeue())
+	benchmarkAdd(b, NewSlicequeue())
 }
 
 func BenchmarkRingAdd(b *testing.B) {
-	benchmarkAdd(b, newringqueue())
+	benchmarkAdd(b, NewRingqueue())
 }
 
 func benchmarkRemove(b *testing.B, q intqueue) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		q.add(i)
+		q.Add(i)
 
-		if q.len() > 10 {
-			q.remove()
+		if q.Len() > 10 {
+			q.Remove()
 		}
 	}
 }
 
 func BenchmarkSliceRemove(b *testing.B) {
-	benchmarkRemove(b, newslicequeue())
+	benchmarkRemove(b, NewSlicequeue())
 }
 
 func BenchmarkRingRemove(b *testing.B) {
-	benchmarkRemove(b, newringqueue())
+	benchmarkRemove(b, NewRingqueue())
 }

--- a/ringqueue.go
+++ b/ringqueue.go
@@ -1,20 +1,20 @@
-package main
+package rinqueue
 
-type ringqueue struct {
-	nodes []int
+type Ringqueue struct {
+	nodes []interface{}
 	head  int
 	tail  int
 	cnt   int
 }
 
-func newringqueue() *ringqueue {
-	return &ringqueue{
-		nodes: make([]int, 2),
+func NewRingqueue() *Ringqueue {
+	return &Ringqueue{
+		nodes: make([]interface{}, 2),
 	}
 }
 
-func (q *ringqueue) resize(n int) {
-	nodes := make([]int, n)
+func (q *Ringqueue) resize(n int) {
+	nodes := make([]interface{}, n)
 	if q.head < q.tail {
 		copy(nodes, q.nodes[q.head:q.tail])
 	} else {
@@ -27,7 +27,7 @@ func (q *ringqueue) resize(n int) {
 	q.nodes = nodes
 }
 
-func (q *ringqueue) add(i int) {
+func (q *Ringqueue) Add(i interface{}) {
 	if q.cnt == len(q.nodes) {
 		// Also tested a grow rate of 1.5, see: http://stackoverflow.com/questions/2269063/buffer-growth-strategy
 		// In Go this resulted in a higher memory usage.
@@ -38,7 +38,7 @@ func (q *ringqueue) add(i int) {
 	q.cnt++
 }
 
-func (q *ringqueue) remove() (int, bool) {
+func (q *Ringqueue) Remove() (interface{}, bool) {
 	if q.cnt == 0 {
 		return 0, false
 	}
@@ -53,10 +53,10 @@ func (q *ringqueue) remove() (int, bool) {
 	return i, true
 }
 
-func (q *ringqueue) cap() int {
+func (q *Ringqueue) Cap() int {
 	return cap(q.nodes)
 }
 
-func (q *ringqueue) len() int {
+func (q *Ringqueue) Len() int {
 	return q.cnt
 }

--- a/slicequeue.go
+++ b/slicequeue.go
@@ -1,17 +1,17 @@
-package main
+package rinqueue
 
-type slicequeue []int
+type Slicequeue []interface{}
 
-func newslicequeue() *slicequeue {
-	q := make(slicequeue, 0)
+func NewSlicequeue() *Slicequeue {
+	q := make(Slicequeue, 0)
 	return &q
 }
 
-func (q *slicequeue) add(i int) {
+func (q *Slicequeue) Add(i interface{}) {
 	*q = append(*q, i)
 }
 
-func (q *slicequeue) remove() (int, bool) {
+func (q *Slicequeue) Remove() (interface{}, bool) {
 	if len(*q) == 0 {
 		return 0, false
 	} else {
@@ -19,7 +19,7 @@ func (q *slicequeue) remove() (int, bool) {
 		*q = (*q)[1:]
 
 		if n := cap(*q) / 2; len(*q) <= n {
-			nodes := make([]int, len(*q), n)
+			nodes := make([]interface{}, len(*q), n)
 			copy(nodes, *q)
 			*q = nodes
 		}
@@ -28,10 +28,10 @@ func (q *slicequeue) remove() (int, bool) {
 	}
 }
 
-func (q *slicequeue) cap() int {
+func (q *Slicequeue) Cap() int {
 	return cap(*q)
 }
 
-func (q *slicequeue) len() int {
+func (q *Slicequeue) Len() int {
 	return len(*q)
 }

--- a/util/main.go
+++ b/util/main.go
@@ -4,25 +4,27 @@ import (
 	"fmt"
 	"runtime"
 	"time"
+
+	rq "github.com/ErikDubbelboer/ringqueue"
 )
 
 func main() {
 	t := time.Tick(time.Second)
-	q := newringqueue()
-	//q := newslicequeue()
+	//q := rq.NewRingqueue()
+	q := rq.NewSlicequeue()
 
 	for i := 1; i > 0; i++ {
-		q.add(i)
+		q.Add(i)
 
-		if q.len() > 10 {
-			q.remove()
+		if q.Len() > 10 {
+			q.Remove()
 		}
 
 		select {
 		case <-t:
 			var m runtime.MemStats
 			runtime.ReadMemStats(&m)
-			fmt.Printf("cap: %d, len: %d, used: %d\n", q.cap(), q.len(), m.Alloc)
+			fmt.Printf("cap: %d, len: %d, used: %d\n", q.Cap(), q.Len(), m.Alloc)
 		default:
 		}
 	}


### PR DESCRIPTION
....and use interface{} type instead of int
Performance suffers, but for the sake of convenience might be OK?

```
$ ./bench.sh 
=== RUN   TestSlicequeue
--- PASS: TestSlicequeue (0.00s)
=== RUN   TestRingqueue
--- PASS: TestRingqueue (0.00s)
PASS
BenchmarkSliceMemory-4         0             0 ns/op
BenchmarkRingMemory-4          0             0 ns/op
BenchmarkSliceAdd-4      1000000           627 ns/op          96 B/op          1 allocs/op
BenchmarkRingAdd-4       3000000           268 ns/op          52 B/op          1 allocs/op
BenchmarkSliceRemove-4  20000000            47.8 ns/op        40 B/op          1 allocs/op
BenchmarkRingRemove-4   20000000            42.8 ns/op         8 B/op          1 allocs/op
ok      github.com/porjo/ringqueue  3.584s
```
